### PR TITLE
Fix tests to wwork with fixture datasets

### DIFF
--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -98,8 +98,9 @@ class StatTracker
   def average_goals_per_game(testing = false)
     testing ? data = game_teams.take(20) : data = game_teams
     numerator = data.sum { |game| game[:goals].to_i }.to_f
-    numerator / data.count
-  end 
+    (numerator / data.count).round(2)
+  end
+
 
   def average_goals_by_season(testing = false)
     testing ? data = game.take(67) : data = game

--- a/runner.rb
+++ b/runner.rb
@@ -2,7 +2,7 @@ require './lib/stat_tracker'
 
 game_path = './data/games_fixture.csv'
 team_path = './data/teams_fixture.csv'
-game_teams_path = './data/game_teams.csv'
+game_teams_path = './data/game_teams_fixture.csv'
 
 locations = {
   games: game_path,

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe StatTracker do
 
   describe '#highest_total_score' do
     it 'returns the highest sum of the winning and losing teams scores' do
-      expect(stat_tracker.highest_total_score(true)).to eq(5)
+      expect(stat_tracker.highest_total_score).to eq(5)
     end
   end
 
@@ -53,27 +53,27 @@ RSpec.describe StatTracker do
 
   describe '#lowest_total_score' do
     it 'returns the lowest sum of the winning and losing teams scores' do
-      expect(stat_tracker.lowest_total_score(true)).to eq(1)
+      expect(stat_tracker.lowest_total_score).to eq(1)
     end
   end
 
 
   describe '#average_goals_per_game' do
     it 'returns the average number of goals scored by a single team' do
-      expect(stat_tracker.average_goals_per_game(true)).to eq(1.85)
+      expect(stat_tracker.average_goals_per_game).to eq(1.98)
     end
   end
 
   describe '#count_of_teams' do
     it 'returns the total number of teams' do
-      expect(stat_tracker.count_of_teams).to eq(32)
+      expect(stat_tracker.count_of_teams).to eq(4)
     end
   end
 
   describe '#average_goals_by_season' do
     it 'returns the average goals scored per season' do
       expected_value = { '20122013' => 3.86, '20142015' => 3.5, '20162017' => 4.75 }
-      expect(stat_tracker.average_goals_by_season(true)).to eq(expected_value)
+      expect(stat_tracker.average_goals_by_season).to eq(expected_value)
     end
   end
 end


### PR DESCRIPTION
This pull request will  allow #average_goals_per_game, #count_of_teams, and #lowest_total_score to test properly with the fixture datasets.